### PR TITLE
HMS-10377: update candlepin workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Update candlepin binding if new release
 on:
-  push:
   workflow_dispatch:
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   CheckLatestVersionAndRun:
     timeout-minutes: 10
@@ -12,11 +16,11 @@ jobs:
       - name: Checkout
         with:
           fetch-depth: 0 # Needed for github-action-get-previous-tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Get current build version
         id: repoRelease
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: "WyriHaximus/github-action-get-previous-tag@v2"
         with:
           prefix: release/
           fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
@@ -62,37 +66,40 @@ jobs:
           -o /local/release \
           -p packageVersion=${{ steps.getRelease.outputs.version }}
 
-      - uses: actions/setup-go@v2
+      - name: Fix release directory permissions
+        if: steps.getRelease.outputs.tag != steps.repoRelease.outputs.tag
+        run: |
+          sudo chown -R "$USER": release/
+
+      - uses: actions/setup-go@v6
         if: steps.getRelease.outputs.tag != steps.repoRelease.outputs.tag
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Run Go Tests
         if: steps.getRelease.outputs.tag != steps.repoRelease.outputs.tag
         run: |
           cd release
-          sudo chmod 777 go.mod go.sum
           go get github.com/stretchr/testify/assert
           go test ./...
 
-      - name: Commit new client
-        id: commit
+      - name: Record tag for release workflow
         if: steps.getRelease.outputs.tag != steps.repoRelease.outputs.tag
-        run: |
-          git config --global user.name ${{secrets.GIT_USER_NAME}}
-          git config --global user.email ${{secrets.GIT_USER_EMAIL}}
-          git add release/
-          git add candlepin-api-spec.yaml
-          git commit -am "Update bindings to ${{ steps.getRelease.outputs.tag }}"
-          git push
-          echo "NEW_SHA=`git rev-parse HEAD`" >> $GITHUB_OUTPUT
+        run: echo "${{ steps.getRelease.outputs.tag }}" > .release-version
 
-      # This pushes an update and release after build <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-      - name: Tag and Release version
-        if: steps.getRelease.outputs.tag != steps.repoRelease.outputs.tag
-        uses: avakar/tag-and-release@v1
+      - name: Create PR for new pulp client
+        if: steps.pulpRelease.outputs.GIT_TAG != steps.repoRelease.outputs.tag
+        uses: peter-evans/create-pull-request@v8
         with:
-          commit: ${{steps.commit.outputs.NEW_SHA}}
-          tag_name: ${{ steps.getRelease.outputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: update-candlepin-bindings-${{ steps.getRelease.outputs.tag }}
+          commit-message: "Update candlepin bindings to ${{ steps.getRelease.outputs.tag }}"
+          title: "Update candlepin bindings to ${{ steps.getRelease.outputs.tag }}"
+          body: |
+            New candlepin version **${{ steps.getRelease.outputs.tag }}** is available.
+            Current build version: ${{ steps.repoRelease.outputs.tag }}
+          labels: |
+            dependencies
+          add-paths: |
+            release/
+            .release-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# Tags and creates a GitHub release when a candlepin bindings PR is merged to the default branch.
+name: Tag and release candlepin bindings
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "release/**"
+      - ".release-version"
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read tag from version file
+        id: version
+        run: |
+          if [ ! -f .release-version ]; then
+            echo "::error::.release-version not found"
+            exit 1
+          fi
+          TAG_NAME=$(cat .release-version)
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Tag and Release version
+        uses: avakar/tag-and-release@v1
+        with:
+          commit: ${{ github.sha }}
+          tag_name: ${{ steps.version.outputs.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR: 
 - updates build workflow to create PR instead of direct commit
 - creates new workflow that will create new tag on push to main

Example of successful run:
https://github.com/content-services/caliri/actions/runs/23339116173

Example PR: 
https://github.com/content-services/caliri/pull/7